### PR TITLE
11 ci test distribution never completes

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,9 +21,3 @@ jobs:
       run: python3 -m pip install --upgrade pip
     - name: Install plcd
       run: python3 -m pip install --upgrade plcd
-    - name: Run plcd
-      run: python3 -m plcd
-    - name: no timeout
-      run: timeout 10 python ./sleep.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
-    - name: timeout # We add or so that return code is not none-zero which causes pipeline to fail
-      run: timeout 1 python ./sleep.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,6 +1,6 @@
 
 
-name: Run Distribution
+name: Check Distribution
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run-dist.yml
+++ b/.github/workflows/run-dist.yml
@@ -23,3 +23,7 @@ jobs:
       run: python3 -m pip install --upgrade plcd
     - name: Run plcd
       run: python3 -m plcd
+    - name: no timeout
+      run: timeout 10 python ./sleep.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
+    - name: timeout # We add or so that return code is not none-zero which causes pipeline to fail
+      run: timeout 1 python ./sleep.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi


### PR DESCRIPTION
Switched `run-dist.yml` to `check-dist.yml` because of looping run error in #11 and test issues. Now, action checks the package distribution but does not run the distributed version as that is covered in other actions.